### PR TITLE
feat: expose honeypot url feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=secret
+DB_NAME=honeypot
+LEGIT_DOMAINS=google.com,github.com

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Um serviço web Python que fornece uma lista atualizada dos endereços IP dos n�
 4. **Acesse o serviço:**
    - Interface web: http://localhost:8000
    - Lista de IPs: http://localhost:8000/tornodes-ip.txt
+   - Lista de URLs: http://localhost:8000/honeypot-urls.txt
 
 ### Instalação com Docker
 
@@ -81,10 +82,11 @@ gunicorn --bind 0.0.0.0:8000 --workers 4 main:app
 
 ### Acesso Rápido
 
-O serviço fornece uma lista de IPs dos nós Tor exit em formato texto simples:
+O serviço fornece uma lista de IPs dos nós Tor exit em formato texto simples e uma lista de URLs maliciosas coletadas do honeypot:
 
 ```bash
 curl https://tor.protexion.cloud/tornodes-ip.txt
+curl https://tor.protexion.cloud/honeypot-urls.txt
 ```
 
 ### Integração em Scripts
@@ -92,6 +94,9 @@ curl https://tor.protexion.cloud/tornodes-ip.txt
 ```bash
 # Baixar apenas os IPs (sem comentários)
 curl -s https://tor.protexion.cloud/tornodes-ip.txt | grep -v "^#"
+
+# Baixar URLs recentes
+curl -s https://tor.protexion.cloud/honeypot-urls.txt | grep -v "^#"
 
 # Salvar em arquivo
 curl -s https://tor.protexion.cloud/tornodes-ip.txt > tor_nodes.txt
@@ -105,22 +110,25 @@ curl -s https://tor.protexion.cloud/tornodes-ip.txt > tor_nodes.txt
 **Exemplo:** [tor.protexion.cloud](https://tor.protexion.cloud)
 
 ### GET `/tornodes-ip.txt`
-**Descrição:** Lista completa de IPs dos nós Tor exit  
-**Formato:** Texto plano  
-**Cache:** 10 dias  
+**Descrição:** Lista completa de IPs dos nós Tor exit
+**Formato:** Texto plano
+**Cache:** 10 dias
+
+### GET `/honeypot-urls.txt`
+**Descrição:** URLs maliciosas registradas pelo honeypot nos últimos 30 dias
+**Formato:** Texto plano
+**Cache:** Sem cache
 **Exemplo:**
 ```
 ################################################################
-# DataN TOR NODE  (IPs only)                                   #
+# Honeypot URLs                                             #
 # Last updated: 2024-01-15 14:30:25 UTC                      #
-# Source: https://check.torproject.org/exit-addresses          #
+# Source: Honeypot cowrie                                    #
 ################################################################
 #
-# DstIP
-192.168.1.1
-10.0.0.1
-...
-# END 1234 entries
+# URL
+http://malicious.example
+# END 1 entries
 ```
 
 ### GET `/status`
@@ -221,6 +229,12 @@ foreach (array_slice($ips, 0, 5) as $ip) {
 | `CACHE_TTL_DAYS` | Dias para renovação do cache | 10 |
 | `PORT` | Porta do servidor | 8000 |
 | `HOST` | Host do servidor | 0.0.0.0 |
+| `DB_HOST` | Host do banco de dados | localhost |
+| `DB_PORT` | Porta do banco de dados | 3306 |
+| `DB_USER` | Usuário do banco de dados | root |
+| `DB_PASSWORD` | Senha do banco de dados | - |
+| `DB_NAME` | Nome do banco de dados | - |
+| `LEGIT_DOMAINS` | Lista de domínios permitidos (separados por vírgula) | - |
 
 ### Arquivos de Cache
 

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -10,11 +10,16 @@ from flask import Flask, render_template, Response, jsonify, request
 from flask_limiter import Limiter
 
 from services.tor_service import TorService
+from services.url_service import UrlService
 from utils.validators import validate_country_code
-from utils.formatters import format_exit_nodes_text, format_rss_feed
+from utils.formatters import (
+    format_exit_nodes_text,
+    format_rss_feed,
+    format_url_list_text,
+)
 
 
-def create_routes(app: Flask, tor_service: TorService, limiter: Limiter) -> None:
+def create_routes(app: Flask, tor_service: TorService, url_service: UrlService, limiter: Limiter) -> None:
     """Cria e registra todas as rotas da aplicação"""
     
     @app.route('/')
@@ -57,7 +62,20 @@ def create_routes(app: Flask, tor_service: TorService, limiter: Limiter) -> None
             logging.error(f"Erro ao buscar tornodes-ip.txt: {e}")
             error_content = format_exit_nodes_text([], None, str(e))
             return Response(error_content, mimetype='text/plain', status=500)
-    
+
+    @app.route('/honeypot-urls.txt')
+    @limiter.limit("30 per minute")
+    def honeypot_urls():
+        """Retorna URLs maliciosas do honeypot em formato texto"""
+        try:
+            urls, last_update = url_service.get_recent_urls()
+            content = format_url_list_text(urls, last_update)
+            return Response(content, mimetype='text/plain')
+        except Exception as e:
+            logging.error(f"Erro ao buscar honeypot-urls.txt: {e}")
+            error_content = format_url_list_text([], None, str(e))
+            return Response(error_content, mimetype='text/plain', status=500)
+
     @app.route('/status')
     @limiter.limit("60 per minute")
     def status():

--- a/app/config/settings.py
+++ b/app/config/settings.py
@@ -1,9 +1,11 @@
-"""
-Configurações da aplicação
-"""
+"""Configurações da aplicação"""
 
 import os
-from typing import Dict, Any
+from typing import Dict, Any, List
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 
 class Config:
@@ -27,9 +29,17 @@ class Config:
     
     # Rate Limiting
     RATE_LIMIT_STORAGE: str = os.getenv('RATE_LIMIT_STORAGE', 'memory://')
-    
+
     # Paths
     CACHE_DIR: str = os.getenv('CACHE_DIR', '/tmp')
+
+    # Database
+    DB_HOST: str = os.getenv('DB_HOST', 'localhost')
+    DB_PORT: int = int(os.getenv('DB_PORT', 3306))
+    DB_USER: str = os.getenv('DB_USER', 'root')
+    DB_PASSWORD: str = os.getenv('DB_PASSWORD', '')
+    DB_NAME: str = os.getenv('DB_NAME', '')
+    LEGIT_DOMAINS: List[str] = [d.strip() for d in os.getenv('LEGIT_DOMAINS', '').split(',') if d.strip()]
     
     @classmethod
     def get_cache_paths(cls) -> Dict[str, str]:

--- a/app/main.py
+++ b/app/main.py
@@ -12,6 +12,7 @@ from flask_limiter.util import get_remote_address
 from config.settings import Config
 from services.tor_service import TorService
 from services.cache_service import CacheService
+from services.url_service import UrlService
 from api.routes import create_routes
 from utils.logger import setup_logger
 
@@ -42,9 +43,11 @@ def create_app() -> Flask:
         cache_service=cache_service,
         request_timeout=app.config['REQUEST_TIMEOUT']
     )
-    
+
+    url_service = UrlService()
+
     # Registrar rotas
-    create_routes(app, tor_service, limiter)
+    create_routes(app, tor_service, url_service, limiter)
     
     # Inicializar cache
     try:
@@ -65,6 +68,7 @@ if __name__ == '__main__':
     print("📋 Endpoints disponíveis:")
     print("   - GET / (página inicial)")
     print("   - GET /tornodes-ip.txt (lista de IPs)")
+    print("   - GET /honeypot-urls.txt (lista de URLs)")
     print("   - GET /status (status do serviço)")
     print("   - GET /api/nodes (todos os nós detalhados)")
     print("   - GET /api/nodes/running (nós ativos)")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -3,3 +3,5 @@ requests==2.31.0
 gunicorn==21.2.0
 Werkzeug==2.3.7
 Flask-Limiter==3.5.0
+pymysql==1.1.0
+python-dotenv==1.0.0

--- a/app/services/url_service.py
+++ b/app/services/url_service.py
@@ -1,0 +1,49 @@
+"""Serviço para buscar URLs maliciosas do banco de dados honeypot"""
+
+from datetime import datetime, timedelta
+from typing import List, Tuple
+from urllib.parse import urlparse
+
+import pymysql
+
+from config.settings import Config
+
+
+class UrlService:
+    """Serviço para consulta de URLs recentes"""
+
+    def __init__(self) -> None:
+        self.db_config = {
+            'host': Config.DB_HOST,
+            'port': Config.DB_PORT,
+            'user': Config.DB_USER,
+            'password': Config.DB_PASSWORD,
+            'database': Config.DB_NAME,
+            'cursorclass': pymysql.cursors.DictCursor,
+        }
+        self.legit_domains = {d.lower() for d in Config.LEGIT_DOMAINS}
+
+    def get_recent_urls(self) -> Tuple[List[str], datetime]:
+        """Retorna URLs com atividade nos últimos 30 dias excluindo domínios legítimos"""
+        cutoff = datetime.utcnow() - timedelta(days=30)
+        query = "SELECT url, last_view FROM urls WHERE last_view >= %s"
+        connection = pymysql.connect(**self.db_config)
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(query, (cutoff,))
+                rows = cursor.fetchall()
+        finally:
+            connection.close()
+
+        urls: List[str] = []
+        last_update = cutoff
+        for row in rows:
+            url = row.get('url')
+            last_view = row.get('last_view')
+            if last_view and last_view > last_update:
+                last_update = last_view
+            domain = urlparse(url).netloc.lower()
+            if domain and domain not in self.legit_domains:
+                urls.append(url)
+
+        return urls, last_update

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -192,6 +192,10 @@
                         <span aria-hidden="true">📄</span>
                         Baixar Lista IPs
                     </a>
+                    <a href="/honeypot-urls.txt" class="btn btn-primary" aria-label="Baixar lista de URLs maliciosas">
+                        <span aria-hidden="true">🔗</span>
+                        Baixar Lista URLs
+                    </a>
                     <a href="/api/nodes" class="btn btn-secondary" aria-label="Acessar API de nós Tor">
                         <span aria-hidden="true">🔗</span>
                         Acessar API
@@ -255,6 +259,11 @@
                             <div class="api-method get">GET</div>
                             <div class="api-path">/tornodes-ip.txt</div>
                             <div class="api-desc">Lista de IPs em formato texto</div>
+                        </div>
+                        <div class="api-endpoint">
+                            <div class="api-method get">GET</div>
+                            <div class="api-path">/honeypot-urls.txt</div>
+                            <div class="api-desc">Lista de URLs maliciosas</div>
                         </div>
                         <div class="api-endpoint">
                             <div class="api-method get">GET</div>

--- a/app/utils/formatters.py
+++ b/app/utils/formatters.py
@@ -1,6 +1,4 @@
-"""
-Funções de formatação de dados
-"""
+"""Funções de formatação de dados"""
 
 from datetime import datetime
 from typing import List, Dict, Any, Optional
@@ -40,6 +38,36 @@ def format_exit_nodes_text(ips: List[str], last_update: Optional[datetime], erro
 """
     
     return header + '\n'.join(ips) + f'\n# END {len(ips)} entries\n'
+
+
+def format_url_list_text(urls: List[str], last_update: Optional[datetime], error: Optional[str] = None) -> str:
+    """Formata lista de URLs para formato texto"""
+
+    if error:
+        return f"""################################################################
+# Honeypot URLs - ERRO                                      #
+# Error occurred: {error}                                     #
+# Last attempt: {datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')} UTC            #
+################################################################
+#
+# Erro ao carregar dados das URLs
+# Tente novamente em alguns minutos
+#
+# END 0 entries
+"""
+
+    updated = last_update.strftime('%Y-%m-%d %H:%M:%S') if last_update else datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+
+    header = f"""################################################################
+# Honeypot URLs                                             #
+# Last updated: {updated} UTC                        #
+# Source: Honeypot cowrie                                    #
+################################################################
+#
+# URL
+"""
+
+    return header + '\n'.join(urls) + f'\n# END {len(urls)} entries\n'
 
 
 def format_rss_feed(nodes: List[Dict[str, Any]], last_update: Optional[datetime]) -> str:


### PR DESCRIPTION
## Summary
- fetch honeypot urls from external database with whitelist
- expose `/honeypot-urls.txt` and link on homepage
- document database env vars and new endpoint

## Testing
- `pip install -r app/requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688f7ab49ed083268b0f93b7de3812fa